### PR TITLE
Filter media library by image dimensions

### DIFF
--- a/wp-content/plugins/scoped-media-library/includes/Admin.php
+++ b/wp-content/plugins/scoped-media-library/includes/Admin.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace SML;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Admin {
+	public function __construct() {
+		add_action( 'admin_menu', [ $this, 'register_settings_page' ] );
+		add_action( 'admin_init', [ $this, 'register_settings' ] );
+	}
+
+	public function register_settings_page() {
+		add_options_page(
+			__( 'Scoped Media Library', 'scoped-media-library' ),
+			__( 'Scoped Media Library', 'scoped-media-library' ),
+			'manage_options',
+			'scoped-media-library',
+			[ $this, 'render_settings_page' ]
+		);
+	}
+
+	public function register_settings() {
+		register_setting( 'sml_settings_group', 'sml_settings', [ $this, 'sanitize_settings' ] );
+
+		add_settings_section(
+			'sml_main_section',
+			__( 'Dimension Rules', 'scoped-media-library' ),
+			function () {
+				echo '<p>' . esc_html__( 'Only images within these dimensions will appear in the media modal.', 'scoped-media-library' ) . '</p>';
+			},
+			'scoped-media-library'
+		);
+
+		add_settings_field( 'min_width', __( 'Minimum Width (px)', 'scoped-media-library' ), [ $this, 'field_number' ], 'scoped-media-library', 'sml_main_section', [ 'key' => 'min_width' ] );
+		add_settings_field( 'min_height', __( 'Minimum Height (px)', 'scoped-media-library' ), [ $this, 'field_number' ], 'scoped-media-library', 'sml_main_section', [ 'key' => 'min_height' ] );
+		add_settings_field( 'max_width', __( 'Maximum Width (px)', 'scoped-media-library' ), [ $this, 'field_number' ], 'scoped-media-library', 'sml_main_section', [ 'key' => 'max_width' ] );
+		add_settings_field( 'max_height', __( 'Maximum Height (px)', 'scoped-media-library' ), [ $this, 'field_number' ], 'scoped-media-library', 'sml_main_section', [ 'key' => 'max_height' ] );
+
+		add_settings_section(
+			'sml_fallback_section',
+			__( 'Fallback', 'scoped-media-library' ),
+			function () {
+				echo '<p>' . esc_html__( 'Allow privileged users to see all images in addition to scoped results.', 'scoped-media-library' ) . '</p>';
+			},
+			'scoped-media-library'
+		);
+
+		add_settings_field( 'fallback_enabled', __( 'Enable Fallback', 'scoped-media-library' ), [ $this, 'field_checkbox' ], 'scoped-media-library', 'sml_fallback_section', [ 'key' => 'fallback_enabled' ] );
+		add_settings_field( 'fallback_capability', __( 'Fallback Capability', 'scoped-media-library' ), [ $this, 'field_text' ], 'scoped-media-library', 'sml_fallback_section', [ 'key' => 'fallback_capability', 'placeholder' => 'manage_options' ] );
+	}
+
+	public function sanitize_settings( $input ) {
+		$sanitized = [];
+		$sanitized['min_width']  = isset( $input['min_width'] ) ? max( 0, intval( $input['min_width'] ) ) : '';
+		$sanitized['min_height'] = isset( $input['min_height'] ) ? max( 0, intval( $input['min_height'] ) ) : '';
+		$sanitized['max_width']  = isset( $input['max_width'] ) ? max( 0, intval( $input['max_width'] ) ) : '';
+		$sanitized['max_height'] = isset( $input['max_height'] ) ? max( 0, intval( $input['max_height'] ) ) : '';
+		$sanitized['fallback_enabled'] = ! empty( $input['fallback_enabled'] ) ? 1 : 0;
+		$sanitized['fallback_capability'] = isset( $input['fallback_capability'] ) && is_string( $input['fallback_capability'] ) ? sanitize_text_field( $input['fallback_capability'] ) : 'manage_options';
+		return $sanitized;
+	}
+
+	public function field_number( $args ) {
+		$options = get_option( 'sml_settings', [] );
+		$key = $args['key'];
+		$value = isset( $options[ $key ] ) ? intval( $options[ $key ] ) : '';
+		echo '<input type="number" min="0" step="1" name="sml_settings[' . esc_attr( $key ) . ']" value="' . esc_attr( $value ) . '" class="small-text" />';
+	}
+
+	public function field_text( $args ) {
+		$options = get_option( 'sml_settings', [] );
+		$key = $args['key'];
+		$placeholder = isset( $args['placeholder'] ) ? $args['placeholder'] : '';
+		$value = isset( $options[ $key ] ) ? $options[ $key ] : '';
+		echo '<input type="text" name="sml_settings[' . esc_attr( $key ) . ']" value="' . esc_attr( $value ) . '" placeholder="' . esc_attr( $placeholder ) . '" class="regular-text" />';
+	}
+
+	public function field_checkbox( $args ) {
+		$options = get_option( 'sml_settings', [] );
+		$key = $args['key'];
+		$checked = ! empty( $options[ $key ] ) ? 'checked' : '';
+		echo '<label><input type="checkbox" name="sml_settings[' . esc_attr( $key ) . ']" value="1" ' . $checked . ' /> ' . esc_html__( 'Enabled', 'scoped-media-library' ) . '</label>';
+	}
+
+	public function render_settings_page() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+		echo '<div class="wrap">';
+		echo '<h1>' . esc_html__( 'Scoped Media Library', 'scoped-media-library' ) . '</h1>';
+		echo '<form method="post" action="options.php">';
+		settings_fields( 'sml_settings_group' );
+		do_settings_sections( 'scoped-media-library' );
+		submit_button();
+		echo '</form>';
+		echo '</div>';
+	}
+}
+

--- a/wp-content/plugins/scoped-media-library/includes/Filters.php
+++ b/wp-content/plugins/scoped-media-library/includes/Filters.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace SML;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Filters {
+	public function __construct() {
+		// AJAX query for media modal
+		add_action( 'pre_get_posts', [ $this, 'filter_media_query' ], 9 );
+		// REST attachments endpoint used by block editor and some builders
+		add_filter( 'rest_attachment_query', [ $this, 'filter_rest_media_query' ], 9, 2 );
+	}
+
+	private function is_media_library_request( $query ) {
+		if ( is_admin() && $query->is_main_query() ) {
+			$p = $query->get( 'post_type' );
+			if ( $p === 'attachment' || ( is_array( $p ) && in_array( 'attachment', $p, true ) ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public function filter_media_query( $query ) {
+		if ( ! $this->is_media_library_request( $query ) ) {
+			return;
+		}
+
+		// Respect mime type filter inside modal
+		$mime_types = $query->get( 'post_mime_type' );
+		if ( $mime_types && strpos( (string) $mime_types, 'image' ) === false ) {
+			return; // only scope images
+		}
+
+		// Fallback: permit all for allowed users
+		if ( \sml_fallback_enabled_for_user() ) {
+			return;
+		}
+
+		$context = [
+			'source' => 'pre_get_posts',
+			'query_vars' => $query->query_vars,
+		];
+		$rules = \sml_get_current_rules( $context );
+		$this->apply_dimension_meta_query( $query, $rules );
+	}
+
+	public function filter_rest_media_query( $args, $request ) {
+		// Only for attachments of image type
+		if ( ! empty( $args['post_mime_type'] ) && strpos( (string) $args['post_mime_type'], 'image' ) === false ) {
+			return $args;
+		}
+
+		if ( \sml_fallback_enabled_for_user() ) {
+			return $args;
+		}
+
+		$context = [
+			'source' => 'rest',
+			'params' => $request ? $request->get_params() : [],
+		];
+		$rules = \sml_get_current_rules( $context );
+
+		// Translate to meta_query constraints
+		if ( empty( $args['meta_query'] ) ) {
+			$args['meta_query'] = [];
+		}
+		$args['meta_query'][] = $this->build_meta_query_clause( '_sml_width', 'min', $rules['min_width'] );
+		$args['meta_query'][] = $this->build_meta_query_clause( '_sml_width', 'max', $rules['max_width'] );
+		$args['meta_query'][] = $this->build_meta_query_clause( '_sml_height', 'min', $rules['min_height'] );
+		$args['meta_query'][] = $this->build_meta_query_clause( '_sml_height', 'max', $rules['max_height'] );
+		$args['meta_query'] = array_values( array_filter( $args['meta_query'] ) );
+		if ( ! empty( $args['meta_query'] ) ) {
+			$args['meta_query']['relation'] = 'AND';
+		}
+		return $args;
+	}
+
+	private function apply_dimension_meta_query( $query, $rules ) {
+		$meta_query = (array) $query->get( 'meta_query', [] );
+		$meta_query[] = $this->build_meta_query_clause( '_sml_width', 'min', $rules['min_width'] );
+		$meta_query[] = $this->build_meta_query_clause( '_sml_width', 'max', $rules['max_width'] );
+		$meta_query[] = $this->build_meta_query_clause( '_sml_height', 'min', $rules['min_height'] );
+		$meta_query[] = $this->build_meta_query_clause( '_sml_height', 'max', $rules['max_height'] );
+		$meta_query = array_values( array_filter( $meta_query ) );
+		if ( ! empty( $meta_query ) ) {
+			$meta_query['relation'] = 'AND';
+			$query->set( 'meta_query', $meta_query );
+		}
+
+		// Ensure we only fetch images
+		$query->set( 'post_mime_type', 'image' );
+	}
+
+	private function build_meta_query_clause( $meta_key, $bound, $value ) {
+		if ( $value === null || $value === '' ) {
+			return null;
+		}
+		$compare = $bound === 'min' ? '>=' : '<=';
+		return [
+			'key'     => $meta_key,
+			'value'   => intval( $value ),
+			'compare' => $compare,
+			'type'    => 'NUMERIC',
+		];
+	}
+}
+

--- a/wp-content/plugins/scoped-media-library/includes/Metadata.php
+++ b/wp-content/plugins/scoped-media-library/includes/Metadata.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace SML;
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Metadata {
+	public function __construct() {
+		add_filter( 'wp_generate_attachment_metadata', [ $this, 'store_primary_dimensions' ], 20, 2 );
+		add_action( 'add_attachment', [ $this, 'maybe_store_dimensions_on_add' ] );
+		add_action( 'edit_attachment', [ $this, 'maybe_store_dimensions_on_edit' ] );
+	}
+
+	public function store_primary_dimensions( $metadata, $attachment_id ) {
+		$mime = get_post_mime_type( $attachment_id );
+		if ( strpos( $mime, 'image/' ) !== 0 ) {
+			return $metadata;
+		}
+		$width  = isset( $metadata['width'] ) ? intval( $metadata['width'] ) : null;
+		$height = isset( $metadata['height'] ) ? intval( $metadata['height'] ) : null;
+		if ( $width && $height ) {
+			update_post_meta( $attachment_id, '_sml_width', $width );
+			update_post_meta( $attachment_id, '_sml_height', $height );
+		}
+		return $metadata;
+	}
+
+	public function maybe_store_dimensions_on_add( $attachment_id ) {
+		$this->store_dimensions_if_missing( $attachment_id );
+	}
+
+	public function maybe_store_dimensions_on_edit( $attachment_id ) {
+		$this->store_dimensions_if_missing( $attachment_id );
+	}
+
+	private function store_dimensions_if_missing( $attachment_id ) {
+		$mime = get_post_mime_type( $attachment_id );
+		if ( strpos( $mime, 'image/' ) !== 0 ) {
+			return;
+		}
+		$has_width  = get_post_meta( $attachment_id, '_sml_width', true );
+		$has_height = get_post_meta( $attachment_id, '_sml_height', true );
+		if ( $has_width && $has_height ) {
+			return;
+		}
+		$file = get_attached_file( $attachment_id );
+		if ( $file && file_exists( $file ) ) {
+			$size = @getimagesize( $file );
+			if ( is_array( $size ) && isset( $size[0], $size[1] ) ) {
+				update_post_meta( $attachment_id, '_sml_width', intval( $size[0] ) );
+				update_post_meta( $attachment_id, '_sml_height', intval( $size[1] ) );
+			}
+		}
+	}
+}
+

--- a/wp-content/plugins/scoped-media-library/readme.txt
+++ b/wp-content/plugins/scoped-media-library/readme.txt
@@ -1,0 +1,48 @@
+=== Scoped Media Library – Filter Images by Dimensions ===
+Contributors: scopingtools
+Tags: media library, images, dimensions, ACF, Beaver Builder, admin
+Requires at least: 6.0
+Tested up to: 6.6
+Requires PHP: 7.4
+Stable tag: 1.0.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+Scoped Media Library allows you to control which images appear in the WordPress media library selector.
+
+== Description ==
+
+Scoped Media Library lets you define dimension rules (min/max width and height) so that only images within those limits are displayed in the media modal. It stores image dimensions on upload and filters the AJAX/REST queries used by the media modal, ACF, Beaver Builder, and other tools.
+
+Features
+
+* Filter by dimensions: Set minimum and maximum width/height for images.
+* Scoped media modal: The WordPress media modal only displays matching images.
+* Faster workflows: Avoid scrolling through irrelevant files.
+* ACF & Beaver Builder compatible.
+* Fallback mode: Allow specific users to see all images.
+* Automatic metadata sync: Dimensions are stored on upload.
+* Developer hooks for per-field overrides via `sml_current_rules`.
+
+== Installation ==
+
+1. Upload the plugin files to `/wp-content/plugins/scoped-media-library/` or install via the Plugins screen.
+2. Activate the plugin through the Plugins screen.
+3. Go to Settings → Scoped Media Library to define your dimension rules.
+4. Open any media selector. Only images within the defined scope will appear.
+
+== Frequently Asked Questions ==
+
+**How does fallback work?**
+
+Administrators (or another capability you choose) can bypass the scope and see all images. Configure this under Settings → Scoped Media Library.
+
+**Can I set different rules for different fields?**
+
+Yes. Developers can hook `sml_current_rules` and inspect request context (e.g., field keys) to return different min/max values.
+
+== Changelog ==
+
+= 1.0.0 =
+* Initial release.
+

--- a/wp-content/plugins/scoped-media-library/scoped-media-library.php
+++ b/wp-content/plugins/scoped-media-library/scoped-media-library.php
@@ -1,0 +1,95 @@
+<?php
+/*
+Plugin Name: Scoped Media Library – Filter Images by Dimensions
+Description: Control which images appear in the media library selector by defining dimension rules (min/max width and height). Compatible with ACF, Beaver Builder, and the WP media modal. Includes optional fallback for admins and stores image dimensions on upload.
+Version: 1.0.0
+Author: Scoped Tools
+License: GPLv2 or later
+Text Domain: scoped-media-library
+*/
+
+// Exit if accessed directly.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+if ( ! defined( 'SML_PLUGIN_FILE' ) ) {
+	define( 'SML_PLUGIN_FILE', __FILE__ );
+}
+
+if ( ! defined( 'SML_PLUGIN_DIR' ) ) {
+	define( 'SML_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+}
+
+if ( ! defined( 'SML_PLUGIN_URL' ) ) {
+	define( 'SML_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+}
+
+// Simple autoloader for this plugin's classes
+spl_autoload_register( function ( $class ) {
+	if ( strpos( $class, 'SML\\' ) !== 0 ) {
+		return;
+	}
+	$path = SML_PLUGIN_DIR . 'includes/' . str_replace( [ 'SML\\', '\\' ], [ '', '/' ], $class ) . '.php';
+	if ( file_exists( $path ) ) {
+		require_once $path;
+	}
+} );
+
+// Activation: set defaults if not present
+register_activation_hook( __FILE__, function () {
+	$defaults = [
+		'min_width'          => '',
+		'min_height'         => '',
+		'max_width'          => '',
+		'max_height'         => '',
+		'fallback_enabled'   => 1,
+		'fallback_capability'=> 'manage_options',
+	];
+	$existing = get_option( 'sml_settings', [] );
+	update_option( 'sml_settings', wp_parse_args( $existing, $defaults ) );
+} );
+
+add_action( 'plugins_loaded', function () {
+	// Instantiate core components
+	new SML\Admin();
+	new SML\Metadata();
+	new SML\Filters();
+} );
+
+// Public helper to fetch current rules (developers can filter)
+function sml_get_current_rules( $context = [] ) {
+	$settings = get_option( 'sml_settings', [] );
+	$rules = [
+		'min_width'  => isset( $settings['min_width'] ) ? intval( $settings['min_width'] ) : null,
+		'min_height' => isset( $settings['min_height'] ) ? intval( $settings['min_height'] ) : null,
+		'max_width'  => isset( $settings['max_width'] ) ? intval( $settings['max_width'] ) : null,
+		'max_height' => isset( $settings['max_height'] ) ? intval( $settings['max_height'] ) : null,
+	];
+
+	/**
+	 * Filter: allow developers to override rules per-field or context.
+	 *
+	 * @param array $rules   Array with keys min_width, min_height, max_width, max_height
+	 * @param array $context Context of the query (e.g., request params, field key)
+	 */
+	return apply_filters( 'sml_current_rules', $rules, $context );
+}
+
+// Public helper to determine if fallback is allowed for current user
+function sml_fallback_enabled_for_user() {
+	$settings = get_option( 'sml_settings', [] );
+	$enabled  = ! empty( $settings['fallback_enabled'] );
+	$cap      = ! empty( $settings['fallback_capability'] ) ? $settings['fallback_capability'] : 'manage_options';
+
+	$allow = $enabled && current_user_can( $cap );
+
+	/**
+	 * Filter: force-enable or disable fallback per request/user.
+	 *
+	 * @param bool  $allow   Whether fallback is allowed
+	 * @param array $settings Plugin settings
+	 */
+	return apply_filters( 'sml_allow_fallback', $allow, $settings );
+}
+


### PR DESCRIPTION
Add the Scoped Media Library plugin to filter WordPress media library images by dimension rules, enhancing media selection workflows.

This plugin introduces a settings page for defining min/max width/height rules, automatically syncs image dimensions on upload, and applies these filters to both classic and REST media queries. It also includes an optional admin fallback to view all images.

---
<a href="https://cursor.com/background-agent?bcId=bc-2608edd1-273d-404d-b799-f8c795712508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2608edd1-273d-404d-b799-f8c795712508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

